### PR TITLE
Add Reveal in Finder option on Treemap objects

### DIFF
--- a/FRTMTools/CacheLocations.swift
+++ b/FRTMTools/CacheLocations.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+enum CacheLocations {
+    static let extractedIPAsRelativePath = "FRTMTools/ExtractedIPAs"
+
+    static var extractedIPAsDirectory: URL {
+        let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+        return caches.appendingPathComponent(extractedIPAsRelativePath, isDirectory: true)
+    }
+
+    static func ensureExtractedIPAsDirectoryExists() {
+        let fm = FileManager.default
+        if !fm.fileExists(atPath: extractedIPAsDirectory.path) {
+            try? fm.createDirectory(at: extractedIPAsDirectory, withIntermediateDirectories: true)
+        }
+    }
+}

--- a/FRTMTools/FRTMTools.swift
+++ b/FRTMTools/FRTMTools.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import AppKit
 
 @main
 struct FRTMTools: App {
@@ -14,6 +15,25 @@ struct FRTMTools: App {
         DependencyRegister.register()
     }
     @State private var showOnboarding = !UserDefaults.standard.bool(forKey: "hasCompletedOnboarding")
+    @State private var showCleanCacheConfirmation = false
+    
+    private var extractedIPAsCacheURL: URL { CacheLocations.extractedIPAsDirectory }
+
+    private func ensureExtractedCacheExists() {
+        CacheLocations.ensureExtractedIPAsDirectoryExists()
+    }
+
+    private func showExtractedIPAsInFinder() {
+        ensureExtractedCacheExists()
+        NSWorkspace.shared.activateFileViewerSelecting([extractedIPAsCacheURL])
+    }
+
+    private func cleanExtractedIPAsCache() {
+        let fm = FileManager.default
+        if fm.fileExists(atPath: extractedIPAsCacheURL.path) {
+            try? fm.removeItem(at: extractedIPAsCacheURL)
+        }
+    }
 
     var body: some Scene {
         WindowGroup {
@@ -21,6 +41,27 @@ struct FRTMTools: App {
                 .sheet(isPresented: $showOnboarding) {
                     OnboardingView(isPresented: $showOnboarding)
                 }
+                .alert("Clean Extracted IPAs Cache?", isPresented: $showCleanCacheConfirmation) {
+                    Button("Delete", role: .destructive) {
+                        cleanExtractedIPAsCache()
+                    }
+                    Button("Cancel", role: .cancel) {}
+                } message: {
+                    Text("This will remove all extracted IPA copies from the cache.")
+                }
+        }
+        .commands {
+            CommandMenu("Cache") {
+                Button("Show Extracted IPAs in Finder") {
+                    showExtractedIPAsInFinder()
+                }
+                .keyboardShortcut("o", modifiers: [.command, .shift])
+
+                Button("Clean Extracted IPAs Cache", role: .destructive) {
+                    showCleanCacheConfirmation = true
+                }
+                .keyboardShortcut(.delete, modifiers: [.command, .shift])
+            }
         }
     }
 }

--- a/FRTMTools/Sources/Analyzers/AppAnalyzer/Core/IPAAnalyzer.swift
+++ b/FRTMTools/Sources/Analyzers/AppAnalyzer/Core/IPAAnalyzer.swift
@@ -86,9 +86,8 @@ final class IPAAnalyzer: Analyzer {
             }
             
             // Persist a copy of the extracted .app into Caches so Finder reveal keeps working
-            let cachesBase = try fm.url(for: .cachesDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
-            let extractedBase = cachesBase.appendingPathComponent("FRTMTools/ExtractedIPAs", isDirectory: true)
-            try? fm.createDirectory(at: extractedBase, withIntermediateDirectories: true)
+            let extractedBase = CacheLocations.extractedIPAsDirectory
+            CacheLocations.ensureExtractedIPAsDirectoryExists()
             let folderName = url.deletingPathExtension().lastPathComponent + "-" + UUID().uuidString
             let targetDir = extractedBase.appendingPathComponent(folderName, isDirectory: true)
             try? fm.createDirectory(at: targetDir, withIntermediateDirectories: true)

--- a/FRTMTools/Sources/Analyzers/AppAnalyzer/Core/IPASizeAnalyzer.swift
+++ b/FRTMTools/Sources/Analyzers/AppAnalyzer/Core/IPASizeAnalyzer.swift
@@ -55,24 +55,15 @@ public final class IPASizeAnalyzer {
             throw IPASizeError.invalidIPAPath
         }
         
-        // 1. Trova e prepara il simulatore
         progress("🔎 Searching for a target simulator...")
         let deviceUDID = try await findAndPrepareSimulator(log: progress)
         progress("🎯 Simulator selected: \(deviceUDID)")
         
-        // 2. Decomprimi e prepara l'app
-        let tempDir = createTempDirectory()
-        defer { try? FileManager.default.removeItem(at: tempDir) }
-        
-        let appPath = try await unzipAndFindApp(ipaPath: normalizedIPAPath, in: tempDir, log: progress)
-        
-        // 3. Installa l'app
         progress("📲 Installing the app...")
-        try await shell(cmd: "/usr/bin/xcrun", args: ["simctl", "install", deviceUDID, appPath])
+        try await shell(cmd: "/usr/bin/xcrun", args: ["simctl", "install", deviceUDID, normalizedIPAPath])
         
-        // 4. Calcola la dimensione
         progress("📊 Calculating installed size...")
-        let result = try await calculateInstalledSize(for: appPath, on: deviceUDID)
+        let result = try await calculateInstalledSize(for: normalizedIPAPath, on: deviceUDID)
         
         progress("🎉 Done!")
         return result

--- a/FRTMTools/Sources/Analyzers/AppAnalyzer/Screens/IPADetailView.swift
+++ b/FRTMTools/Sources/Analyzers/AppAnalyzer/Screens/IPADetailView.swift
@@ -142,7 +142,19 @@ struct DetailView: View {
                 .padding(.horizontal)
                 
                 // Tips Section
-                TipsSection(tips: TipGenerator.generateTips(for: analysis))
+                // Compute a base URL for resolving relative paths in tips
+                let tipsBaseURL: URL? = {
+                    let appURL = analysis.url
+                    let fm = FileManager.default
+                    var isDir: ObjCBool = false
+                    let contents = appURL.appendingPathComponent("Contents")
+                    if fm.fileExists(atPath: contents.path, isDirectory: &isDir), isDir.boolValue {
+                        return contents // macOS bundle layout
+                    }
+                    return appURL
+                }()
+                
+                TipsSection(tips: TipGenerator.generateTips(for: analysis), baseURL: tipsBaseURL)
                     .padding(.top)
             }
             .padding(.vertical, 16)

--- a/FRTMTools/Sources/Analyzers/AppAnalyzer/Views/TipsSection.swift
+++ b/FRTMTools/Sources/Analyzers/AppAnalyzer/Views/TipsSection.swift
@@ -1,7 +1,9 @@
 import SwiftUI
+import AppKit
 
 struct TipsSection: View {
     let tips: [Tip]
+    let baseURL: URL?
     @State private var expandedTips: Set<UUID> = []
 
     var body: some View {
@@ -13,42 +15,56 @@ struct TipsSection: View {
 
             ForEach(tips) { tip in
                 VStack(spacing: 0) {
-                    Button(action: {
-                        if !tip.subTips.isEmpty {
-                            toggle(tip: tip)
+                    HStack(alignment: .top) {
+                        Text(emoji(for: tip.category))
+                            .font(.title3)
+                        VStack(alignment: .leading) {
+                            Text(tip.category.rawValue)
+                                .font(.headline)
+                            Text(tip.text)
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
                         }
-                    }) {
-                        HStack(alignment: .top) {
-                            Text(emoji(for: tip.category))
-                                .font(.title3)
-                            VStack(alignment: .leading) {
-                                Text(tip.category.rawValue)
-                                    .font(.headline)
-                                Text(tip.text)
-                                    .font(.subheadline)
-                                    .foregroundColor(.secondary)
-                            }
-                            
-                            Spacer()
-                            
-                            if !tip.subTips.isEmpty {
+                        
+                        Spacer()
+                        
+                        if !tip.subTips.isEmpty {
+                            Button(action: {
+                                toggle(tip: tip)
+                            }) {
                                 Image(systemName: expandedTips.contains(tip.id) ? "chevron.up" : "chevron.down")
                             }
+                            .buttonStyle(.plain)
                         }
-                        .padding()
-                        .contentShape(Rectangle())
                     }
-                    .buttonStyle(.plain)
+                    .padding()
+                    .textSelection(.enabled)
                     
                     if expandedTips.contains(tip.id) {
                         LazyVStack(alignment: .leading, spacing: 8) {
                             ForEach(tip.subTips) { subTip in
-                                HStack(alignment: .top) {
+                                HStack(alignment: .top, spacing: 8) {
                                     Text(emoji(for: subTip.category))
                                         .font(.body)
-                                    Text(subTip.text)
-                                        .font(.body)
-                                        .foregroundColor(.secondary)
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        let lines = subTip.text.split(whereSeparator: \.isNewline)
+                                        ForEach(Array(lines.enumerated()), id: \.offset) { _, rawLine in
+                                            let line = String(rawLine)
+                                            HStack(alignment: .firstTextBaseline, spacing: 6) {
+                                                Text(line)
+                                                    .font(.body)
+                                                    .foregroundColor(.secondary)
+                                                if isPathCandidate(line) {
+                                                    Button(action: { reveal(path: line) }) {
+                                                        Image(systemName: "folder")
+                                                    }
+                                                    .buttonStyle(.plain)
+                                                    .font(.system(size: 12))
+                                                    .help("Reveal in Finder")
+                                                }
+                                            }
+                                        }
+                                    }
                                     Spacer()
                                 }
                                 .padding(.leading, 28)
@@ -56,6 +72,7 @@ struct TipsSection: View {
                         }
                         .padding(.bottom)
                         .padding(.horizontal)
+                        .textSelection(.enabled)
                         .transition(.opacity.combined(with: .move(edge: .top)))
                     }
                 }
@@ -79,5 +96,40 @@ struct TipsSection: View {
         case .warning: return "⚠️"
         case .info: return "ℹ️"
         }
+    }
+    
+    private func isPathCandidate(_ raw: String) -> Bool {
+        let s = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "'\""))
+        guard !s.isEmpty else { return false }
+        // Heuristics: treat lines containing a slash as paths, but ignore summary lines
+        if s.localizedCaseInsensitiveContains("potential saving") { return false }
+        if s.hasPrefix("\u{2022}") { return false } // bullet
+        return s.contains("/") || s.hasPrefix("/")
+    }
+    
+    private func reveal(path rawPath: String) {
+        let trimmed = rawPath.trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "'\""))
+        let targetURL: URL?
+        if trimmed.hasPrefix("/") {
+            targetURL = URL(fileURLWithPath: trimmed)
+        } else if let baseURL = baseURL {
+            targetURL = baseURL.appendingPathComponent(trimmed)
+        } else {
+            targetURL = nil
+        }
+        guard let initialURL = targetURL else { return }
+        let fm = FileManager.default
+        var candidate = initialURL
+        var last = candidate.path
+        while !fm.fileExists(atPath: candidate.path) {
+            let parent = candidate.deletingLastPathComponent()
+            if parent.path == last { break }
+            last = parent.path
+            candidate = parent
+        }
+        guard fm.fileExists(atPath: candidate.path) else { return }
+        NSWorkspace.shared.activateFileViewerSelecting([candidate])
     }
 }

--- a/FRTMTools/Sources/Analyzers/AppAnalyzer/Views/Treemap/ExpandableGraphView.swift
+++ b/FRTMTools/Sources/Analyzers/AppAnalyzer/Views/Treemap/ExpandableGraphView.swift
@@ -30,7 +30,19 @@ struct ExpandableGraphView: View {
                 .buttonStyle(.plain)
             }
 
-            TreemapAnalysisView(root: analysis.rootFile)
+            let baseURL: URL? = {
+                let appURL = analysis.url
+                let fm = FileManager.default
+                var isDir: ObjCBool = false
+                let contents = appURL.appendingPathComponent("Contents")
+                if fm.fileExists(atPath: contents.path, isDirectory: &isDir), isDir.boolValue {
+                    return contents // macOS bundle layout
+                }
+                // Fallback: use appURL even if it may not currently exist on disk
+                return appURL
+            }()
+
+            TreemapAnalysisView(root: analysis.rootFile, baseURL: baseURL)
                 .frame(height: 300)
 
             TreemapLegendView()
@@ -52,28 +64,40 @@ private struct ExpandedDetailView: View {
     @Binding var isShowingDetail: Bool
 
     var body: some View {
-            VStack {
-                HStack {
-                    Text("Treemap Detail")
-                        .font(.title2).bold()
-                    Spacer()
-                    Button(action: { isShowingDetail = false }) {
-                        Image(systemName: "xmark.circle.fill")
-                            .font(.title2)
-                            .foregroundColor(.secondary)
-                    }
-                    .buttonStyle(.plain)
+        let baseURL: URL? = {
+            let appURL = analysis.url
+            let fm = FileManager.default
+            var isDir: ObjCBool = false
+            let contents = appURL.appendingPathComponent("Contents")
+            if fm.fileExists(atPath: contents.path, isDirectory: &isDir), isDir.boolValue {
+                return contents // macOS bundle layout
+            }
+            // Fallback: use appURL even if it may not currently exist on disk
+            return appURL
+        }()
+
+        return VStack {
+            HStack {
+                Text("Treemap Detail")
+                    .font(.title2).bold()
+                Spacer()
+                Button(action: { isShowingDetail = false }) {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.title2)
+                        .foregroundColor(.secondary)
                 }
-                .padding()
-                
-                TreemapAnalysisView(root: analysis.rootFile)
-                
-                TreemapLegendView()
-                    .padding()
+                .buttonStyle(.plain)
             }
             .padding()
-            .frame(minWidth: 1200, minHeight: 800)
-            .background(Color(NSColor.controlBackgroundColor))
+            
+            TreemapAnalysisView(root: analysis.rootFile, baseURL: baseURL)
+            
+            TreemapLegendView()
+                .padding()
+        }
+        .padding()
+        .frame(minWidth: 1200, minHeight: 800)
+        .background(Color(NSColor.controlBackgroundColor))
     }
 }
 


### PR DESCRIPTION
Add Reveal in Finder right-click option on Treemap objects:
<img width="862" height="437" alt="Screenshot 2025-10-01 alle 20 10 19" src="https://github.com/user-attachments/assets/141eca8d-9e31-4318-8a9e-f6d0eb6f8630" />

This is possible by caching the extracted IPA. A cache is kept and can be cleaned:
<img width="569" height="108" alt="Screenshot 2025-10-01 alle 20 27 00" src="https://github.com/user-attachments/assets/7fe76fe8-aea6-4d41-97f2-06a3e50f97d9" />

Paths in suggestions are now possible to open in finder:
<img width="870" height="161" alt="Screenshot 2025-10-01 alle 21 35 49" src="https://github.com/user-attachments/assets/fc7d3694-496b-4c88-ac01-ddbe53025836" />

