### PR TITLE
Add Binary Composition analysis for IPA files

### DIFF
--- a/FRTMTools/Sources/Analyzers/AppAnalyzer/Components/IPA/BinaryCompositionOnDemandSection.swift
+++ b/FRTMTools/Sources/Analyzers/AppAnalyzer/Components/IPA/BinaryCompositionOnDemandSection.swift
@@ -1,0 +1,288 @@
+//
+//  BinaryCompositionOnDemandSection.swift
+//  FRTMTools
+//
+//  Created by Claude Code
+//
+
+import SwiftUI
+
+struct BinaryCompositionOnDemandSection: View {
+    let binaryURL: URL
+    let appBundleURL: URL?
+    @Environment(\.theme) private var theme
+
+    @State private var state: AnalysisState = .idle
+    @State private var composition: BinaryComposition?
+    @State private var errorMessage: String?
+
+    private enum AnalysisState: Equatable {
+        case idle
+        case analyzing
+        case completed
+        case failed
+
+        var iconName: String {
+            switch self {
+            case .idle: return "cube.transparent"
+            case .analyzing: return "clock.arrow.2.circlepath"
+            case .completed: return "checkmark.circle"
+            case .failed: return "xmark.circle"
+            }
+        }
+
+        var accentColor: Color {
+            switch self {
+            case .idle: return .accentColor
+            case .analyzing: return .orange
+            case .completed: return .green
+            case .failed: return .red
+            }
+        }
+
+        var description: String {
+            switch self {
+            case .idle:
+                return "Analizza il binario principale per identificare librerie statiche e pacchetti SPM integrati."
+            case .analyzing:
+                return "Stiamo analizzando i simboli del binario, potrebbe richiedere qualche secondo."
+            case .completed:
+                return "Analisi completata. Puoi esplorare i moduli rilevati di seguito."
+            case .failed:
+                return "Si è verificato un errore durante l'analisi. Riprova."
+            }
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            header
+            Divider()
+            content
+            footer
+        }
+        .padding(24)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(theme.palette.surface)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .stroke(theme.palette.border)
+        )
+        .shadow(color: theme.palette.shadow.opacity(theme.colorScheme == .dark ? 0.25 : 0.08), radius: 6, x: 0, y: 3)
+        .animation(.spring(response: 0.35, dampingFraction: 0.85), value: state)
+    }
+
+    private var header: some View {
+        HStack(alignment: .center, spacing: 16) {
+            ZStack {
+                Circle()
+                    .fill(
+                        LinearGradient(
+                            colors: [
+                                state.accentColor.opacity(0.25),
+                                state.accentColor.opacity(0.6)
+                            ],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                    )
+                Image(systemName: state.iconName)
+                    .font(.system(size: 24, weight: .semibold))
+                    .foregroundStyle(.white)
+            }
+            .frame(width: 52, height: 52)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Binary Composition")
+                    .font(.title3.bold())
+                Text(state.description)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            statusBadge
+        }
+    }
+
+    private var content: some View {
+        Group {
+            switch state {
+            case .idle:
+                placeholder()
+            case .analyzing:
+                placeholder(showProgress: true)
+            case .completed:
+                if let composition = composition {
+                    BinaryCompositionView(composition: composition)
+                }
+            case .failed:
+                failedView
+            }
+        }
+    }
+
+    private var footer: some View {
+        HStack(alignment: .center, spacing: 8) {
+            Image(systemName: "info.circle")
+                .foregroundStyle(.secondary)
+            Text("Questa analisi estrae simboli dal binario per stimare le dimensioni delle librerie integrate.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var statusBadge: some View {
+        HStack(spacing: 8) {
+            Circle()
+                .fill(state.accentColor)
+                .frame(width: 8, height: 8)
+            Text(statusLabel)
+                .font(.footnote.weight(.semibold))
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+        .background(
+            Capsule(style: .continuous)
+                .fill(state.accentColor.opacity(0.12))
+        )
+        .overlay(
+            Capsule(style: .continuous)
+                .stroke(state.accentColor.opacity(0.4))
+        )
+    }
+
+    private var statusLabel: String {
+        switch state {
+        case .idle: return "On-Demand"
+        case .analyzing: return "Analisi"
+        case .completed: return "Completata"
+        case .failed: return "Errore"
+        }
+    }
+
+    private func placeholder(showProgress: Bool = false) -> some View {
+        VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(showProgress ? "Analisi in corso..." : "Analisi su richiesta")
+                    .font(.headline)
+                Text("Premi il pulsante per analizzare la composizione del binario principale.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+
+            if showProgress {
+                HStack(spacing: 12) {
+                    ProgressView()
+                        .progressViewStyle(.circular)
+                    Text("Estrazione simboli e analisi moduli...")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+            } else {
+                CTAButton(title: "Avvia analisi", systemImage: "play.circle.fill") {
+                    startAnalysis()
+                }
+            }
+        }
+        .padding(20)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(
+                    LinearGradient(
+                        colors: [
+                            Color.accentColor.opacity(0.12),
+                            Color.accentColor.opacity(0.05)
+                        ],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .stroke(Color.accentColor.opacity(0.3))
+        )
+    }
+
+    private var failedView: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Analisi fallita")
+                    .font(.headline)
+                    .foregroundStyle(.red)
+                if let error = errorMessage {
+                    Text(error)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            CTAButton(title: "Riprova", systemImage: "arrow.clockwise.circle.fill") {
+                startAnalysis()
+            }
+        }
+        .padding(20)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(
+                    LinearGradient(
+                        colors: [
+                            Color.red.opacity(0.12),
+                            Color.red.opacity(0.05)
+                        ],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .stroke(Color.red.opacity(0.3))
+        )
+    }
+
+    private func startAnalysis() {
+        guard state != .analyzing else { return }
+        state = .analyzing
+        errorMessage = nil
+
+        Task {
+            let analyzer = StaticLibraryAnalyzer()
+            let result = await analyzer.analyze(binaryURL: binaryURL, appBundleURL: appBundleURL)
+
+            await MainActor.run {
+                if let result = result {
+                    composition = result
+                    state = .completed
+                } else {
+                    errorMessage = "Impossibile analizzare il binario. Verifica che il file esista e sia un binario Mach-O valido."
+                    state = .failed
+                }
+            }
+        }
+    }
+}
+
+// MARK: - CTA Button
+
+private struct CTAButton: View {
+    let title: String
+    let systemImage: String
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Label(title, systemImage: systemImage)
+                .font(.headline)
+                .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.borderedProminent)
+        .controlSize(.large)
+    }
+}

--- a/FRTMTools/Sources/Analyzers/AppAnalyzer/Components/IPA/BinaryCompositionView.swift
+++ b/FRTMTools/Sources/Analyzers/AppAnalyzer/Components/IPA/BinaryCompositionView.swift
@@ -1,0 +1,423 @@
+//
+//  BinaryCompositionView.swift
+//  FRTMTools
+//
+//  Created by Claude Code
+//
+
+import SwiftUI
+
+struct BinaryCompositionView: View {
+    let composition: BinaryComposition
+    @Environment(\.theme) private var theme
+
+    private let byteFormatter: ByteCountFormatter = {
+        let formatter = ByteCountFormatter()
+        formatter.countStyle = .file
+        formatter.includesUnit = true
+        formatter.isAdaptive = true
+        return formatter
+    }()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            summarySection
+            Divider()
+
+            if !composition.analysisWarnings.isEmpty {
+                warningsSection
+            }
+
+            segmentChart
+            Divider()
+
+            if !composition.staticModules.isEmpty {
+                staticModulesSection
+                Divider()
+            }
+
+            if !composition.spmPackages.isEmpty {
+                spmPackagesSection
+                Divider()
+            }
+
+            if !composition.systemFrameworks.isEmpty {
+                systemFrameworksSection
+            }
+        }
+    }
+
+    // MARK: - Summary Section
+
+    private var summarySection: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(spacing: 24) {
+                summaryItem(
+                    title: "Binary Size",
+                    value: byteFormatter.string(fromByteCount: composition.totalSize),
+                    icon: "doc.fill"
+                )
+
+                summaryItem(
+                    title: "Static Modules",
+                    value: "\(composition.staticModuleCount)",
+                    icon: "archivebox",
+                    tint: .orange
+                )
+
+                summaryItem(
+                    title: "SPM Packages",
+                    value: "\(composition.spmPackageCount)",
+                    icon: "shippingbox",
+                    tint: .blue
+                )
+
+                summaryItem(
+                    title: "System APIs",
+                    value: "\(composition.systemFrameworks.count)",
+                    icon: "gearshape.2",
+                    tint: .gray
+                )
+            }
+
+            HStack(spacing: 16) {
+                if composition.isEncrypted {
+                    statusBadge(text: "Encrypted", icon: "lock.fill", color: .orange)
+                }
+                if composition.isStripped {
+                    statusBadge(text: "Stripped", icon: "scissors", color: .yellow)
+                }
+                if !composition.isEncrypted && !composition.isStripped {
+                    statusBadge(text: "Decrypted", icon: "lock.open.fill", color: .green)
+                }
+            }
+        }
+    }
+
+    private func summaryItem(title: String, value: String, icon: String, tint: Color = .accentColor) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: icon)
+                .font(.title2)
+                .foregroundStyle(tint)
+                .frame(width: 32)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(value)
+                    .font(.headline)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func statusBadge(text: String, icon: String, color: Color) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: icon)
+                .font(.caption)
+            Text(text)
+                .font(.caption.weight(.medium))
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 5)
+        .background(
+            Capsule()
+                .fill(color.opacity(0.15))
+        )
+        .overlay(
+            Capsule()
+                .stroke(color.opacity(0.4))
+        )
+        .foregroundStyle(color)
+    }
+
+    // MARK: - Warnings Section
+
+    private var warningsSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            ForEach(composition.analysisWarnings, id: \.self) { warning in
+                HStack(spacing: 8) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.yellow)
+                    Text(warning)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color.yellow.opacity(0.1))
+        )
+    }
+
+    // MARK: - Segment Chart
+
+    private var segmentChart: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Segment Breakdown")
+                .font(.headline)
+
+            if composition.segments.isEmpty {
+                Text("No segments found")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            } else {
+                GeometryReader { geometry in
+                    let totalSize = composition.segments.reduce(0) { $0 + $1.size }
+                    HStack(spacing: 2) {
+                        ForEach(composition.segments) { segment in
+                            let proportion = totalSize > 0 ? CGFloat(segment.size) / CGFloat(totalSize) : 0
+                            let width = max(proportion * geometry.size.width, 20)
+
+                            VStack(spacing: 4) {
+                                Rectangle()
+                                    .fill(segmentColor(for: segment.name))
+                                    .frame(width: width, height: 24)
+                                    .clipShape(RoundedRectangle(cornerRadius: 4))
+
+                                Text(segment.name)
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                                    .lineLimit(1)
+                            }
+                        }
+                    }
+                }
+                .frame(height: 50)
+
+                // Legend
+                FlowLayout(spacing: 12) {
+                    ForEach(composition.segments) { segment in
+                        HStack(spacing: 4) {
+                            Circle()
+                                .fill(segmentColor(for: segment.name))
+                                .frame(width: 8, height: 8)
+                            Text("\(segment.name): \(byteFormatter.string(fromByteCount: segment.size))")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func segmentColor(for name: String) -> Color {
+        switch name {
+        case "__TEXT": return .blue
+        case "__DATA", "__DATA_CONST": return .green
+        case "__LINKEDIT": return .orange
+        case "__OBJC_CONST", "__OBJC_RO": return .purple
+        default: return .gray
+        }
+    }
+
+    // MARK: - Static Modules Section
+
+    private var staticModulesSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Image(systemName: "archivebox")
+                    .foregroundStyle(.orange)
+                Text("Static Modules")
+                    .font(.headline)
+                Spacer()
+                Text("\(composition.staticModules.count) modules")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            let totalSize = composition.staticModules.reduce(0) { $0 + $1.estimatedSize }
+            if totalSize > 0 {
+                Text("Estimated Total: \(byteFormatter.string(fromByteCount: totalSize))")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            LazyVStack(spacing: 6) {
+                ForEach(composition.staticModules) { module in
+                    StaticModuleRow(module: module, byteFormatter: byteFormatter)
+                }
+            }
+        }
+    }
+
+    // MARK: - SPM Packages Section
+
+    private var spmPackagesSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Image(systemName: "shippingbox")
+                    .foregroundStyle(.blue)
+                Text("SPM Packages")
+                    .font(.headline)
+                Spacer()
+                Text("\(composition.spmPackages.count) packages")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            let totalSPMSize = composition.spmPackages.reduce(0) { $0 + $1.size }
+            if totalSPMSize > 0 {
+                Text("Total: \(byteFormatter.string(fromByteCount: totalSPMSize))")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            LazyVStack(spacing: 6) {
+                ForEach(composition.spmPackages) { pkg in
+                    SPMPackageRow(package: pkg, byteFormatter: byteFormatter)
+                }
+            }
+        }
+    }
+
+    // MARK: - System Frameworks Section
+
+    private var systemFrameworksSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Image(systemName: "gearshape.2")
+                    .foregroundStyle(.gray)
+                Text("System Frameworks")
+                    .font(.headline)
+                Spacer()
+                Text("\(composition.systemFrameworks.count) frameworks")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            FlowLayout(spacing: 8) {
+                ForEach(composition.systemFrameworks, id: \.self) { framework in
+                    Text(framework)
+                        .font(.caption)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(
+                            Capsule()
+                                .fill(Color.gray.opacity(0.15))
+                        )
+                }
+            }
+        }
+    }
+}
+
+// MARK: - SPM Package Row
+
+private struct SPMPackageRow: View {
+    let package: SPMPackageInfo
+    let byteFormatter: ByteCountFormatter
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "shippingbox")
+                .font(.body)
+                .foregroundStyle(.blue)
+                .frame(width: 24)
+
+            Text(package.name)
+                .font(.subheadline)
+                .fontWeight(.medium)
+
+            Spacer()
+
+            Text(package.size > 0 ? package.sizeText : "—")
+                .font(.subheadline)
+                .fontWeight(.medium)
+                .monospacedDigit()
+                .foregroundStyle(package.size > 0 ? .primary : .secondary)
+        }
+        .padding(.vertical, 6)
+        .padding(.horizontal, 12)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(theme.palette.surface.opacity(0.5))
+        )
+    }
+}
+
+// MARK: - Static Module Row
+
+private struct StaticModuleRow: View {
+    let module: StaticModuleInfo
+    let byteFormatter: ByteCountFormatter
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "archivebox")
+                .font(.body)
+                .foregroundStyle(.orange)
+                .frame(width: 24)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(module.name)
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                Text("\(module.symbolCount) symbols")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            Text(module.estimatedSize > 0 ? module.sizeText : "—")
+                .font(.subheadline)
+                .fontWeight(.medium)
+                .monospacedDigit()
+                .foregroundStyle(module.estimatedSize > 0 ? .primary : .secondary)
+        }
+        .padding(.vertical, 6)
+        .padding(.horizontal, 12)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(theme.palette.surface.opacity(0.5))
+        )
+    }
+}
+
+// MARK: - Flow Layout
+
+private struct FlowLayout: Layout {
+    var spacing: CGFloat = 8
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let result = flowLayout(proposal: proposal, subviews: subviews)
+        return result.size
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        let result = flowLayout(proposal: proposal, subviews: subviews)
+        for (index, position) in result.positions.enumerated() {
+            subviews[index].place(at: CGPoint(x: bounds.minX + position.x, y: bounds.minY + position.y), proposal: .unspecified)
+        }
+    }
+
+    private func flowLayout(proposal: ProposedViewSize, subviews: Subviews) -> (size: CGSize, positions: [CGPoint]) {
+        let maxWidth = proposal.width ?? .infinity
+        var positions: [CGPoint] = []
+        var currentX: CGFloat = 0
+        var currentY: CGFloat = 0
+        var lineHeight: CGFloat = 0
+
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if currentX + size.width > maxWidth && currentX > 0 {
+                currentX = 0
+                currentY += lineHeight + spacing
+                lineHeight = 0
+            }
+            positions.append(CGPoint(x: currentX, y: currentY))
+            currentX += size.width + spacing
+            lineHeight = max(lineHeight, size.height)
+        }
+
+        return (CGSize(width: maxWidth, height: currentY + lineHeight), positions)
+    }
+}

--- a/FRTMTools/Sources/Analyzers/AppAnalyzer/Models/BinaryComposition.swift
+++ b/FRTMTools/Sources/Analyzers/AppAnalyzer/Models/BinaryComposition.swift
@@ -1,0 +1,121 @@
+//
+//  BinaryComposition.swift
+//  FRTMTools
+//
+//  Created by Claude Code
+//
+
+import Foundation
+
+// MARK: - Binary Composition Models
+
+/// Overall result of binary composition analysis
+struct BinaryComposition: Codable, Sendable {
+    let binaryURL: URL
+    let binaryName: String
+    let totalSize: Int64
+    let segments: [SegmentInfo]
+    let isEncrypted: Bool
+    let isStripped: Bool
+    let analysisWarnings: [String]
+
+    // SPM packages (dynamically linked)
+    let spmPackages: [SPMPackageInfo]
+    let systemFrameworks: [String]
+
+    // Statically linked modules (detected from symbols)
+    let staticModules: [StaticModuleInfo]
+
+    var textSegmentSize: Int64 {
+        segments.first { $0.name == "__TEXT" }?.size ?? 0
+    }
+
+    var dataSegmentSize: Int64 {
+        segments.filter { $0.name == "__DATA" || $0.name == "__DATA_CONST" }
+            .reduce(0) { $0 + $1.size }
+    }
+
+    var linkeditSegmentSize: Int64 {
+        segments.first { $0.name == "__LINKEDIT" }?.size ?? 0
+    }
+
+    var spmPackageCount: Int {
+        spmPackages.count
+    }
+
+    var staticModuleCount: Int {
+        staticModules.count
+    }
+
+    init(
+        binaryURL: URL,
+        binaryName: String,
+        totalSize: Int64,
+        segments: [SegmentInfo],
+        isEncrypted: Bool = false,
+        isStripped: Bool = false,
+        analysisWarnings: [String] = [],
+        spmPackages: [SPMPackageInfo] = [],
+        systemFrameworks: [String] = [],
+        staticModules: [StaticModuleInfo] = []
+    ) {
+        self.binaryURL = binaryURL
+        self.binaryName = binaryName
+        self.totalSize = totalSize
+        self.segments = segments
+        self.isEncrypted = isEncrypted
+        self.isStripped = isStripped
+        self.analysisWarnings = analysisWarnings
+        self.spmPackages = spmPackages
+        self.systemFrameworks = systemFrameworks
+        self.staticModules = staticModules
+    }
+}
+
+/// Information about a Mach-O segment
+struct SegmentInfo: Codable, Sendable, Identifiable {
+    var id: String { name }
+    let name: String
+    let size: Int64
+    let vmAddress: UInt64
+    let fileOffset: UInt64
+
+    var sizeText: String {
+        ByteCountFormatter.string(fromByteCount: size, countStyle: .file)
+    }
+}
+
+/// Information about an SPM package detected from linked libraries
+struct SPMPackageInfo: Codable, Sendable, Identifiable {
+    var id: String { name }
+    let name: String
+    let fullName: String
+    let size: Int64
+
+    var sizeText: String {
+        ByteCountFormatter.string(fromByteCount: size, countStyle: .file)
+    }
+}
+
+/// Information about a statically linked module detected from symbols
+struct StaticModuleInfo: Codable, Sendable, Identifiable {
+    var id: String { name }
+    let name: String
+    let symbolCount: Int
+    let estimatedSize: Int64
+
+    var sizeText: String {
+        ByteCountFormatter.string(fromByteCount: estimatedSize, countStyle: .file)
+    }
+
+    /// Known system/runtime modules to filter out
+    static let systemModules: Set<String> = [
+        "Swift", "Foundation", "UIKit", "SwiftUI", "Combine",
+        "CoreFoundation", "CoreGraphics", "QuartzCore", "ObjectiveC",
+        "Dispatch", "Darwin", "os", "simd"
+    ]
+
+    var isSystemModule: Bool {
+        Self.systemModules.contains(name)
+    }
+}

--- a/FRTMTools/Sources/Analyzers/AppAnalyzer/Screens/IPA/IPADetailView.swift
+++ b/FRTMTools/Sources/Analyzers/AppAnalyzer/Screens/IPA/IPADetailView.swift
@@ -108,6 +108,12 @@ struct DetailView<ViewModel: AppDetailViewModel>: View {
                     DependencyGraphOnDemandSection(graph: dependencyGraph)
                         .padding(.horizontal)
                 }
+
+                // Binary Composition Section (on demand)
+                if let ipaVM = viewModel as? IPADetailViewModel, let mainBinaryURL = ipaVM.mainBinaryURL {
+                    BinaryCompositionOnDemandSection(binaryURL: mainBinaryURL, appBundleURL: ipaVM.appBundleURL)
+                        .padding(.horizontal)
+                }
                 
                 HStack(alignment: .top, spacing: 24) {
                     // Pie chart

--- a/FRTMTools/Sources/Analyzers/AppAnalyzer/SubAnalyzer/IPA/StaticLibraryAnalyzer.swift
+++ b/FRTMTools/Sources/Analyzers/AppAnalyzer/SubAnalyzer/IPA/StaticLibraryAnalyzer.swift
@@ -1,0 +1,422 @@
+//
+//  StaticLibraryAnalyzer.swift
+//  FRTMTools
+//
+//  Created by Claude Code
+//
+
+import Foundation
+
+/// Analyzer for detecting SPM packages, embedded frameworks, and modules in a Mach-O binary
+public final class StaticLibraryAnalyzer: @unchecked Sendable {
+
+    // MARK: - Public API
+
+    /// Analyze a binary to detect embedded SPM packages, frameworks, and modules
+    /// - Parameters:
+    ///   - binaryURL: URL to the main executable binary
+    ///   - appBundleURL: Optional URL to the .app bundle (for framework size calculation)
+    func analyze(binaryURL: URL, appBundleURL: URL? = nil) async -> BinaryComposition? {
+        guard FileManager.default.fileExists(atPath: binaryURL.path) else {
+            return nil
+        }
+
+        var warnings: [String] = []
+
+        // Get binary file size
+        let totalSize: Int64
+        do {
+            let attrs = try FileManager.default.attributesOfItem(atPath: binaryURL.path)
+            totalSize = attrs[.size] as? Int64 ?? 0
+        } catch {
+            totalSize = 0
+        }
+
+        // Check if binary is encrypted
+        let isEncrypted = await checkIfEncrypted(at: binaryURL)
+        if isEncrypted {
+            warnings.append("Binary is encrypted (FairPlay DRM)")
+        }
+
+        // Analyze segments (filter out __PAGEZERO)
+        let segments = await analyzeSegments(at: binaryURL)
+            .filter { $0.name != "__PAGEZERO" }
+
+        // Check if binary is stripped
+        let isStripped = await checkIfStripped(at: binaryURL)
+
+        // Extract linked libraries using otool -L
+        let (linkedLibs, systemFrameworks) = await extractLinkedLibraries(from: binaryURL)
+
+        // Detect SPM packages from linked libraries (dynamic)
+        let spmPackages = detectSPMPackages(from: linkedLibs, frameworksURL: appBundleURL?.appendingPathComponent("Frameworks"))
+
+        // Detect statically linked modules from symbols
+        let textSize = segments.first { $0.name == "__TEXT" }?.size ?? 0
+        let staticModules = await extractStaticModules(from: binaryURL, textSegmentSize: textSize, isStripped: isStripped)
+
+        return BinaryComposition(
+            binaryURL: binaryURL,
+            binaryName: binaryURL.lastPathComponent,
+            totalSize: totalSize,
+            segments: segments,
+            isEncrypted: isEncrypted,
+            isStripped: isStripped,
+            analysisWarnings: warnings,
+            spmPackages: spmPackages,
+            systemFrameworks: systemFrameworks,
+            staticModules: staticModules
+        )
+    }
+
+    // MARK: - Encryption Check
+
+    private func checkIfEncrypted(at binaryURL: URL) async -> Bool {
+        guard let output = await runProcess(
+            executablePath: "/usr/bin/otool",
+            arguments: ["-l", binaryURL.path]
+        ) else { return false }
+
+        // Look for LC_ENCRYPTION_INFO with cryptid 1
+        let lines = output.components(separatedBy: "\n")
+        var inEncryptionInfo = false
+
+        for line in lines {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.contains("LC_ENCRYPTION_INFO") {
+                inEncryptionInfo = true
+            } else if inEncryptionInfo && trimmed.hasPrefix("cryptid") {
+                let parts = trimmed.components(separatedBy: " ")
+                if let cryptid = parts.last, cryptid == "1" {
+                    return true
+                }
+                inEncryptionInfo = false
+            }
+        }
+        return false
+    }
+
+    // MARK: - Segment Analysis
+
+    private func analyzeSegments(at binaryURL: URL) async -> [SegmentInfo] {
+        guard let output = await runProcess(
+            executablePath: "/usr/bin/otool",
+            arguments: ["-l", binaryURL.path]
+        ) else { return [] }
+
+        return parseSegments(from: output)
+    }
+
+    private func parseSegments(from output: String) -> [SegmentInfo] {
+        var segments: [SegmentInfo] = []
+        let lines = output.components(separatedBy: "\n")
+
+        var currentSegmentName: String?
+        var currentVMSize: Int64 = 0
+        var currentVMAddr: UInt64 = 0
+        var currentFileOff: UInt64 = 0
+
+        for line in lines {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+
+            if trimmed.hasPrefix("segname") {
+                // Save previous segment if exists
+                if let name = currentSegmentName, currentVMSize > 0 {
+                    segments.append(SegmentInfo(
+                        name: name,
+                        size: currentVMSize,
+                        vmAddress: currentVMAddr,
+                        fileOffset: currentFileOff
+                    ))
+                }
+                // Parse new segment name
+                let parts = trimmed.components(separatedBy: " ")
+                currentSegmentName = parts.last
+                currentVMSize = 0
+                currentVMAddr = 0
+                currentFileOff = 0
+            } else if trimmed.hasPrefix("vmsize") {
+                if let hexStr = trimmed.components(separatedBy: " ").last,
+                   let value = parseHexOrDecimal(hexStr) {
+                    currentVMSize = Int64(value)
+                }
+            } else if trimmed.hasPrefix("vmaddr") {
+                if let hexStr = trimmed.components(separatedBy: " ").last,
+                   let value = parseHexOrDecimal(hexStr) {
+                    currentVMAddr = value
+                }
+            } else if trimmed.hasPrefix("fileoff") {
+                if let hexStr = trimmed.components(separatedBy: " ").last,
+                   let value = parseHexOrDecimal(hexStr) {
+                    currentFileOff = value
+                }
+            }
+        }
+
+        // Don't forget the last segment
+        if let name = currentSegmentName, currentVMSize > 0 {
+            segments.append(SegmentInfo(
+                name: name,
+                size: currentVMSize,
+                vmAddress: currentVMAddr,
+                fileOffset: currentFileOff
+            ))
+        }
+
+        return segments
+            .filter { $0.size > 0 }
+            .sorted { $0.size > $1.size }
+    }
+
+    private func parseHexOrDecimal(_ str: String) -> UInt64? {
+        if str.hasPrefix("0x") {
+            return UInt64(str.dropFirst(2), radix: 16)
+        }
+        return UInt64(str)
+    }
+
+    // MARK: - Stripped Check
+
+    private func checkIfStripped(at binaryURL: URL) async -> Bool {
+        guard let output = await runProcess(
+            executablePath: "/usr/bin/file",
+            arguments: [binaryURL.path]
+        ) else { return false }
+
+        return output.contains("stripped")
+    }
+
+    // MARK: - Static Module Extraction
+
+    /// Extract Swift module names from binary symbols using nm
+    private func extractStaticModules(from binaryURL: URL, textSegmentSize: Int64, isStripped: Bool) async -> [StaticModuleInfo] {
+        // Don't try symbol extraction on stripped binaries
+        if isStripped {
+            return []
+        }
+
+        guard let output = await runProcess(
+            executablePath: "/usr/bin/nm",
+            arguments: [binaryURL.path]
+        ) else { return [] }
+
+        // Count symbols per Swift module
+        var moduleCounts: [String: Int] = [:]
+        let lines = output.components(separatedBy: "\n")
+
+        for line in lines {
+            // Swift mangled symbols start with _$s followed by module name length and name
+            // Example: _$s8DGCharts15ChartDataEntryC... -> module "DGCharts" (length 8)
+            guard let range = line.range(of: "_$s") ?? line.range(of: " _$s") else { continue }
+
+            let afterPrefix = String(line[range.upperBound...])
+            guard let moduleName = parseSwiftModuleName(from: afterPrefix) else { continue }
+
+            // Skip very short names (likely parsing errors)
+            guard moduleName.count >= 2 else { continue }
+
+            moduleCounts[moduleName, default: 0] += 1
+        }
+
+        // Filter out system modules and sort by count
+        let totalSymbols = moduleCounts.values.reduce(0, +)
+
+        var modules: [StaticModuleInfo] = []
+        for (name, count) in moduleCounts {
+            // Skip system modules
+            if StaticModuleInfo.systemModules.contains(name) { continue }
+
+            // Skip modules with very few symbols (likely noise)
+            guard count >= 10 else { continue }
+
+            // Estimate size based on symbol proportion
+            let proportion = Double(count) / Double(max(totalSymbols, 1))
+            let estimatedSize = Int64(proportion * Double(textSegmentSize))
+
+            modules.append(StaticModuleInfo(
+                name: name,
+                symbolCount: count,
+                estimatedSize: estimatedSize
+            ))
+        }
+
+        return modules.sorted { $0.symbolCount > $1.symbolCount }
+    }
+
+    /// Parse Swift module name from mangled symbol
+    /// Format: <length><name>... where length is decimal digits
+    private func parseSwiftModuleName(from str: String) -> String? {
+        var index = str.startIndex
+        var lengthStr = ""
+
+        // Read digits for length
+        while index < str.endIndex, str[index].isNumber {
+            lengthStr.append(str[index])
+            index = str.index(after: index)
+        }
+
+        guard let length = Int(lengthStr), length > 0, length <= 50 else { return nil }
+
+        // Read module name
+        let endIndex = str.index(index, offsetBy: length, limitedBy: str.endIndex) ?? str.endIndex
+        let moduleName = String(str[index..<endIndex])
+
+        // Validate it looks like a module name (alphanumeric + underscore)
+        guard moduleName.allSatisfy({ $0.isLetter || $0.isNumber || $0 == "_" }) else { return nil }
+
+        return moduleName
+    }
+
+    // MARK: - Linked Libraries Extraction
+
+    private func extractLinkedLibraries(from binaryURL: URL) async -> (embedded: [String], system: [String]) {
+        guard let output = await runProcess(
+            executablePath: "/usr/bin/otool",
+            arguments: ["-L", binaryURL.path]
+        ) else { return ([], []) }
+
+        var embedded: [String] = []
+        var system: [String] = []
+
+        let lines = output.components(separatedBy: "\n")
+        for line in lines {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+
+            // Skip the first line (binary path) and empty lines
+            guard !trimmed.isEmpty else { continue }
+
+            // Extract the library path (before version info)
+            let libPath = trimmed.components(separatedBy: " (").first ?? trimmed
+
+            if libPath.contains("@rpath") {
+                // Embedded library - extract framework/dylib name
+                // Format: @rpath/Name.framework/Name or @rpath/libName.dylib
+                var name = libPath.replacingOccurrences(of: "@rpath/", with: "")
+
+                if name.contains(".framework/") {
+                    // Extract framework name (part before .framework/)
+                    name = name.components(separatedBy: ".framework/").first ?? name
+                } else if name.hasSuffix(".dylib") {
+                    // Remove .dylib extension
+                    name = String(name.dropLast(6))
+                }
+
+                // Remove any remaining path components
+                name = name.components(separatedBy: "/").first ?? name
+
+                embedded.append(name)
+            } else if libPath.hasPrefix("/System/Library/Frameworks/") {
+                // System framework
+                let name = libPath
+                    .replacingOccurrences(of: "/System/Library/Frameworks/", with: "")
+                    .components(separatedBy: ".framework").first ?? ""
+                if !name.isEmpty {
+                    system.append(name)
+                }
+            }
+        }
+
+        return (Array(Set(embedded)).sorted(), Array(Set(system)).sorted())
+    }
+
+    // MARK: - SPM Package Detection
+
+    /// SPM Package Product pattern: ModuleName_HASH_PackageProduct
+    private let spmPackagePattern = try! NSRegularExpression(
+        pattern: "^(.+)_-?[A-Fa-f0-9]+_PackageProduct$",
+        options: []
+    )
+
+    private func detectSPMPackages(from linkedLibs: [String], frameworksURL: URL?) -> [SPMPackageInfo] {
+        var packages: [SPMPackageInfo] = []
+
+        for lib in linkedLibs {
+            let range = NSRange(lib.startIndex..., in: lib)
+            if let match = spmPackagePattern.firstMatch(in: lib, options: [], range: range),
+               let nameRange = Range(match.range(at: 1), in: lib) {
+                let packageName = String(lib[nameRange])
+                let size = getFrameworkSize(named: lib, in: frameworksURL)
+
+                packages.append(SPMPackageInfo(
+                    name: packageName,
+                    fullName: lib,
+                    size: size
+                ))
+            }
+        }
+
+        return packages.sorted { $0.size > $1.size }
+    }
+
+    // MARK: - Framework Size Helper
+
+    private func getFrameworkSize(named name: String, in frameworksURL: URL?) -> Int64 {
+        guard let frameworksURL = frameworksURL else { return 0 }
+
+        // Try .framework first
+        let frameworkPath = frameworksURL.appendingPathComponent("\(name).framework")
+        if let size = directorySize(at: frameworkPath) {
+            return size
+        }
+
+        // Try .dylib
+        let dylibPath = frameworksURL.appendingPathComponent("\(name).dylib")
+        if let attrs = try? FileManager.default.attributesOfItem(atPath: dylibPath.path),
+           let size = attrs[.size] as? Int64 {
+            return size
+        }
+
+        // Try without extension (some packages have different structures)
+        let plainPath = frameworksURL.appendingPathComponent(name)
+        if let size = directorySize(at: plainPath) {
+            return size
+        }
+
+        return 0
+    }
+
+    private func directorySize(at url: URL) -> Int64? {
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+
+        var totalSize: Int64 = 0
+        let enumerator = FileManager.default.enumerator(at: url, includingPropertiesForKeys: [.fileSizeKey])
+
+        while let fileURL = enumerator?.nextObject() as? URL {
+            if let attrs = try? FileManager.default.attributesOfItem(atPath: fileURL.path),
+               let size = attrs[.size] as? Int64 {
+                totalSize += size
+            }
+        }
+
+        return totalSize > 0 ? totalSize : nil
+    }
+
+    // MARK: - Process Helper
+
+    private func runProcess(executablePath: String, arguments: [String]) async -> String? {
+        let tempFile = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: tempFile) }
+
+        do {
+            FileManager.default.createFile(atPath: tempFile.path, contents: nil)
+            guard let fileHandle = FileHandle(forWritingAtPath: tempFile.path) else { return nil }
+
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: executablePath)
+            process.arguments = arguments
+            process.standardOutput = fileHandle
+            process.standardError = FileHandle.nullDevice
+
+            try process.run()
+            process.waitUntilExit()
+
+            try? fileHandle.close()
+
+            let data = try Data(contentsOf: tempFile)
+            return String(data: data, encoding: .utf8)
+        } catch {
+            return nil
+        }
+    }
+}

--- a/FRTMTools/Sources/Analyzers/AppAnalyzer/ViewModels/IPA/IPADetailViewModel.swift
+++ b/FRTMTools/Sources/Analyzers/AppAnalyzer/ViewModels/IPA/IPADetailViewModel.swift
@@ -62,4 +62,28 @@ final class IPADetailViewModel: AppDetailViewModel {
         return map
     }()
 
+    /// URL to the main executable binary within the app bundle
+    var mainBinaryURL: URL? {
+        guard let executableName = analysis.executableName else { return nil }
+        let fm = FileManager.default
+
+        // iOS app structure: AppName.app/ExecutableName
+        let iosPath = analysis.url.appendingPathComponent(executableName)
+        if fm.fileExists(atPath: iosPath.path) {
+            return iosPath
+        }
+
+        // macOS app structure: AppName.app/Contents/MacOS/ExecutableName
+        let macPath = analysis.url.appendingPathComponent("Contents/MacOS/\(executableName)")
+        if fm.fileExists(atPath: macPath.path) {
+            return macPath
+        }
+
+        return nil
+    }
+
+    /// URL to the .app bundle for framework size calculations
+    var appBundleURL: URL {
+        analysis.url
+    }
 }


### PR DESCRIPTION
- Detect statically linked Swift modules from binary symbols using nm
- Detect dynamically linked SPM packages from otool -L output
- Show Mach-O segment breakdown (__TEXT, __DATA, __LINKEDIT)
- Display system frameworks used by the app
- Estimate module sizes based on symbol count proportion
- Check encryption status (FairPlay DRM) and stripped status
- On-demand analysis to avoid slowing down initial IPA load
<img width="834" height="664" alt="Screenshot 2026-01-25 alle 17 53 14" src="https://github.com/user-attachments/assets/420e80c2-c229-4fbf-bbfb-fc12b59977c1" />
<img width="708" height="362" alt="Screenshot 2026-01-25 alle 18 20 28" src="https://github.com/user-attachments/assets/b1f92b36-66f4-4f85-978c-166a29511b9e" />

<img width="839" height="302" alt="Screenshot 2026-01-25 alle 17 53 22" src="https://github.com/user-attachments/assets/42832912-91c8-412b-a36c-57d3586c858f" />

